### PR TITLE
New: improved handling of historical snapshots

### DIFF
--- a/actions/dump.js
+++ b/actions/dump.js
@@ -1,8 +1,6 @@
-#!/usr/bin/env node
-
-// Dump Intercom data to S3
 var _ = require('lodash');
 var Promise = require('bluebird');
+var retry = require('bluebird-retry');
 var AWS = require('aws-sdk');
 var zlib = require('zlib');
 var Intercom = require('intercom-client');
@@ -12,74 +10,207 @@ var extend = require('xtend');
 var s3 = new AWS.S3({ apiVersion: '2006-03-01' });
 
 // Environment
-var INTERCOM_APPID = process.env.INTERCOM_APPID || '';
 var INTERCOM_ACCESSTOKEN = process.env.INTERCOM_ACCESSTOKEN || '';
 var S3BUCKET = process.env.S3BUCKET || '';
 
+// Create join tabls for these many-to-many relationships
+var RESOURCE_RELATIONSHIPS = {
+  user: ['segment', 'tag']
+}
+var TO_SINGULAR = {
+  users: 'user',
+  companies: 'company',
+  segments: 'segment',
+  tags: 'tag'
+};
+
+
+// Timestamp formatting
 var HIVE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+var S3_DATE_FORMAT = 'YYYYMMDD-HHmm';
 var OBSERVED_AT = moment();
 var _observed_at = OBSERVED_AT.format(HIVE_DATE_FORMAT);
 
+
 module.exports = dump;
 
+var client = new Intercom.Client({ token: INTERCOM_ACCESSTOKEN });
+
 function dump(event, context, cb) {
-  if (!INTERCOM_APPID || !INTERCOM_ACCESSTOKEN || !S3BUCKET) return cb('Missing required fields.');
+  if (!INTERCOM_ACCESSTOKEN) return cb('Intercom access token is required to retrieve data.');
+  if (!S3BUCKET) return cb('Amazon S3 bucket is required to write data.');
 
-  var client = new Intercom.Client({ token: INTERCOM_ACCESSTOKEN });
+  // 1. snapshot list resources
+  listResources().each(uploadSnapshot)
+    // 2. snapshot scroll resources
+    .then(scrollResources).each(uploadSnapshot)
+    // 3. update events
+    .each(uploadResourceEvents)
+    .then(function() { return cb })
+    .catch(function(ex) { return cb(ex) });
+}
 
-  // Retrieve records from Intercom
-  var pSegments = client.segments.list();
-  var pUsers = new Promise(function(resolve, reject) {
-    var users = [];
-    client.users.scroll.each({}, function(res) {
-      users = users.concat(res.body.users);
+// Wrap in function to allow us to control order of evaluation
+function listResources() {
+  // listAll IS NOT mappable
+  return Promise.map(['segments', 'tags'], function(r) { return listAll(r); });
+}
+
+function scrollResources() {
+  // scrollAll IS mappable
+  return Promise.mapSeries(['users'], scrollAll); // TODO: add leads and companies
+}
+
+
+//
+// Intercom utils
+//
+
+// Get all items for scrolled resources
+function scrollAll(resource) {
+  return new Promise(function(resolve, reject) {
+    var items = [];
+    client[resource].scroll.each({}, function(res) {
+      items = items.concat(res.body[resource]);
     })
-    .then(function() { resolve(users); })
+    .then(function() { resolve({ resource: resource, items: items }); })
     .catch(function(ex) { reject(ex); });
   });
-
-  // Write output
-  pSegments
-    .then(function(res) { return write('segments', res.body.segments); })
-    .then(function() { return pUsers; })
-    .then(function(users) { return write('users', users); })
-    .then(function(users) {
-      var relationships = [
-        write('segment_memberships', createJoinTable('segment', users)),
-        write('tag_memberships', createJoinTable('tag', users))
-      ];
-      return Promise.all(relationships);
-    })
-    .then(function() { return cb; })
-    .catch(function(ex) { return cb(ex); });
 }
 
-function write(table, content) {
+// Get all items for paged resources
+function listAll(resource, filter, pages, memo = []) {
+  function next(res) {
+    if (res.pages) return listAll(resource, filter, res.pages, memo.concat(res.body[resource]));
+    return { resource: resource, items: memo.concat(res.body[resource]) };
+  }
+
+  if (pages) {
+    // Create closure for retry
+    var fn = function(x) { return client.nextPage(x); };
+    return retry(fn, { args: [pages] }).then(next);
+  }
+  if (filter) {
+    // Create closure for retry
+    var fn = function(x) { return client[resource].listBy(x); };
+    return retry(fn, { args: [filter] }).then(next);
+  }
+  var fn = function() { return client[resource].list(); };
+  return retry(fn).then(next);
+}
+
+
+//
+// AWS S3 utils
+//
+function uploadObject(key, items) {
+  // Compress JSON to minimize cost when scanning via Athena
+  var body = zlib.gzipSync(toNDJson(items));
+
   return new Promise(function(resolve, reject) {
-    s3.upload({
-      Bucket: S3BUCKET,
-      Key: `${table}/${OBSERVED_AT.format('YYYYMMDD-HHmm')}.ndjson.gz`,
-      Body: zlib.gzipSync(toNDJson(content))
-    }, function(err, data) {
-      if (err) reject(err);
-      resolve(content);
-    });
-  })
-}
-
-function createJoinTable(key, users) {
-  var relationships = users.map(function(u) {
-    return _.get(u, `${key}s.${key}s`).map(function(r) {
-      return { user_id: u.id, [`${key}_id`]: r.id };
+    s3.upload({ Bucket: S3BUCKET, Key: key, Body: body }, function(err, data) {
+      if (err) return reject(err);
+      console.log(`Uploaded ${key}`);
+      return resolve(key);
     });
   });
-  return _.flatten(relationships);
 }
 
-// Stringify collection to new line delimited JSON
+function copyObject(source, target) {
+  return new Promise(function(resolve, reject) {
+    s3.copyObject({ Bucket: S3BUCKET, CopySource: source, Key: target }, function(err, data) {
+      if (err) return reject(err);
+      console.log(`Copied ${source} to ${target}`);
+      return resolve(target);
+    });
+  });
+}
+
+function deleteObject(key) {
+  return new Promise(function(resolve, reject) {
+    s3.deleteObject({ Bucket: S3BUCKET, Key: key }, function(err, data) {
+      if (err) return reject(err);
+      console.log(`Deleted ${key}`);
+      return resolve(key);
+    });
+  });
+}
+
+function listObjects(prefix) {
+  return new Promise(function(resolve, reject) {
+    s3.listObjects({ Bucket: S3BUCKET, Prefix: prefix }, function(err, data) {
+      if (err) return reject(err);
+      return resolve(data.Contents.map(function (o) { return o.Key; }));
+    });
+  });
+}
+
+
+// Static-ish resources, like users, are more easily joined to time series data if only distinct records exist
+function uploadSnapshot(data) {
+  var resource = data.resource;
+  var items = data.items;
+  var key = `${resource}/${OBSERVED_AT.format(S3_DATE_FORMAT)}.ndjson.gz`;
+
+  var pExpiredObjects = listObjects(resource);
+
+  return Promise.map(pExpiredObjects, deleteObject)
+    .then(function() { return uploadObject(key, items); })
+    .then(function() { return copyObject(`${S3BUCKET}/${key}`, `historical-${key}`); })
+    .then(function() { return uploadRelationships(data); });
+}
+
+// Coordinate the creation of join tables for many-to-many relationships
+function uploadRelationships(data) {
+  var resource = TO_SINGULAR[data.resource];
+  var joins = RESOURCE_RELATIONSHIPS[resource];
+
+  if (!joins) return;
+
+  var items = data.items;
+  var joinTables = joins.map(function(relationship) { return createJoinTable(resource, items, relationship); });
+
+  return Promise.each(joinTables, uploadSnapshot);
+}
+
+// Create join tables to connect segments and tags to users and companies
+function createJoinTable(resource, items, relationship) {
+  var joins = items.map(function(i) {
+    return _.get(i, `${relationship}s.${relationship}s`).map(function(r) {
+      return { [`${resource}_id`]: i.id, [`${relationship}_id`]: r.id };
+    });
+  });
+  return { resource: `${relationship}_memberships`, items: _.flatten(joins) };
+}
+
+function uploadResourceEvents(data) {
+  if (data.resource !== 'users') return;
+  return Promise.map(data.items, uploadEvents, { concurrency: 5 });
+}
+
+function uploadEvents(user) {
+  if (user.type !== 'user') return;
+
+  // Can only request all events for a user. Would be ideal if they could be filtered by timestamp
+  var filter = {
+    type: 'user',
+    intercom_user_id: user.id
+  };
+
+  return listAll('events', filter).then(function(res) {
+    if (res.items.length == 0) return;
+    // Partition by user for improved performance. Simpler to overwrite all events than to only add new ones.
+    return uploadObject(`events/${user.id}.ndjson.gz`, res.items);
+  })
+  .catch(function(ex) {
+    console.log(`error: failed to retrieve events for user ${user.id}`);
+  });
+}
+
+// Stringify collection to newline delimited JSON
 function toNDJson(collection) {
   return collection.map(function(item) {
-    // Extend each record with the date-time it was observed
+    // Extend each record with the date-time it was observed by us
     return JSON.stringify(extend(item, { _observed_at: _observed_at }));
   }).join('\n');
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "aws-sdk": "^2.9.0",
     "bluebird": "^3.4.7",
+    "bluebird-retry": "^0.10.1",
     "intercom-client": "^2.8.6",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,10 @@ bl@~1.1.2:
   dependencies:
     readable-stream "~2.0.5"
 
+bluebird-retry@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.10.1.tgz#cdf76b01d4a6dd4fec4e2c84360a8a09007f67da"
+
 bluebird@^3.3.4, bluebird@^3.4.7:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"


### PR DESCRIPTION
Joining users, segments and tags is messy if they are snapshots.
Store historical snapshots in `historical-TABLE` to allow easier joins.

Most recent snapshot of data is available under simple table names (e.g. `users`, `segment_memberships`) while historical snapshots are prefixed with `historical-` (e.g. `historical-users`)

Adds events. Closes #5 